### PR TITLE
Secure guest login: drop GuestBackend auth, fix create_guest_user

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+# Changelog
+
+## Unreleased
+
+### Security
+
+- **`GuestBackend` must not be used for guest login.** `GuestBackend.authenticate()`
+  no longer returns a user (it ignored passwords, which allowed re-login to guest
+  accounts via the normal login form when the guest identifier is public).
+- **`maybe_create_guest_user`** now logs guests in with
+  `django.contrib.auth.backends.ModelBackend` (configurable via
+  `GUEST_USER_LOGIN_BACKEND`) instead of authenticating through `GuestBackend`.
+  Guests get a one-time session at creation and cannot re-authenticate afterwards.
+
+### Changed
+
+- System check **`guest_user.W001`** now **warns when `GuestBackend` is
+  registered** (previously errored when it was missing).
+- **`create_guest_user`**: on username collision (`IntegrityError`), email and
+  password are regenerated together with the new username.
+- **`create_guest_user(username=...)`**: always binds `guest+{username}@liqd.net`
+  email and a generated password.
+
+### Migration for downstream projects
+
+1. Remove `guest_user.backends.GuestBackend` from `AUTHENTICATION_BACKENDS`.
+2. Remove `SILENCED_SYSTEM_CHECKS = ["guest_user.W001"]` if added only for the
+   old check.
+3. `GuestCreateView` can call `maybe_create_guest_user(request)` again (or keep
+   explicit `create_guest_user` + `login` — equivalent with this release).

--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@ on Read the Docs.
 ## Quickstart
 
 1. Install the `django-guest-user` package from PyPI
-2. Add `guest_user` to your `INSTALLED_APPS` and migrate your database
-3. Add `guest_user.backends.GuestBackend` to your `AUTHENTICATION_BACKENDS`
-4. Include `guest_user.urls` in your URLs
-5. Decorate your views with `@allow_guest_user`:
+2. Add `guest_user` to your `INSTALLED_APPS` and migrate your database. Do **not**
+   add `guest_user.backends.GuestBackend` to `AUTHENTICATION_BACKENDS` (see
+   `CHANGELOG.md`).
+3. Include `guest_user.urls` in your URLs
+4. Decorate your views with `@allow_guest_user`:
 
    ```python
    from guest_user.decorators import allow_guest_user

--- a/docs/setup.rst
+++ b/docs/setup.rst
@@ -28,9 +28,9 @@ and :ref:`django:ref/settings:``authentication_backends```::
 
    AUTHENTICATION_BACKENDS = [
       "django.contrib.auth.backends.ModelBackend",
-      # it should be the last entry to prevent unauthorized access
-      "guest_user.backends.GuestBackend",
    ]
+
+   Do **not** register ``guest_user.backends.GuestBackend`` — see ``CHANGELOG.md``.
 
 Allow guests to convert to registered users by adding the URLs to your :doc:`URLconf<django:topics/http/urls>`::
 

--- a/guest_user/app_settings.py
+++ b/guest_user/app_settings.py
@@ -236,3 +236,18 @@ class AppSettings:
 
         """
         return self.get("MODEL", "guest_user.Guest")
+
+    @property
+    def LOGIN_BACKEND(self) -> str:
+        """
+        Auth backend used when logging a guest in after creation.
+
+        Use a password-checking backend (typically ``ModelBackend``). Do **not**
+        use ``guest_user.backends.GuestBackend`` here.
+
+        :default: ``"django.contrib.auth.backends.ModelBackend"``
+
+        """
+        return self.get(
+            "LOGIN_BACKEND", "django.contrib.auth.backends.ModelBackend"
+        )

--- a/guest_user/backends.py
+++ b/guest_user/backends.py
@@ -5,22 +5,18 @@ from .functions import is_guest_user
 
 
 class GuestBackend(ModelBackend):
+    """Deprecated authentication backend.
+
+    Earlier versions authenticated guests by identifier alone (ignoring the
+    password), which allowed anyone who knew a guest's public username or email
+    to log into that account via the normal login form.
+
+    **Do not add this backend to** ``AUTHENTICATION_BACKENDS``. Guest sessions
+    are started by :func:`guest_user.functions.maybe_create_guest_user` using
+    ``GUEST_USER_LOGIN_BACKEND`` (``ModelBackend`` by default).
+    """
+
     def authenticate(self, request, username=None, password=None, **kwargs):
-        """Authenticate with username only."""
-
-#        if password is not None:
-#            # Prevent authentication when a password was supplied and
-#            # all previous authentication backends have failed.
-#            return None
-
-        UserModel = get_user_model()
-
-        try:
-            user = UserModel.objects.get(**{UserModel.USERNAME_FIELD: username})
-        except UserModel.DoesNotExist:
-            return None
-        if is_guest_user(user):
-            return user
         return None
 
     def get_user(self, user_id):
@@ -29,4 +25,6 @@ class GuestBackend(ModelBackend):
             user = UserModel._default_manager.get(pk=user_id)
         except UserModel.DoesNotExist:
             return None
-        return user
+        if is_guest_user(user):
+            return user
+        return None

--- a/guest_user/checks.py
+++ b/guest_user/checks.py
@@ -1,5 +1,5 @@
 from django.conf import settings as django_settings
-from django.core.checks import Error, Warning, register
+from django.core.checks import Warning, register
 
 from . import settings
 
@@ -10,26 +10,17 @@ def check_settings(app_configs, **kwargs):
 
     guest_backend = "guest_user.backends.GuestBackend"
 
-    if (
-        settings.ENABLED
-        and guest_backend not in django_settings.AUTHENTICATION_BACKENDS
-    ):
-        checks.append(
-            Error(
-                "The GuestBackend is not in your AUTHENTICATION_BACKENDS. Authenticating guest users will not work.",
-                hint='Add "guest_user.backends.GuestBackend" to the AUTHENTICATION_BACKENDS setting.',
-                obj="settings",
-                id="guest_user.W001",
-            )
-        )
-    elif (
-        settings.ENABLED
-        and django_settings.AUTHENTICATION_BACKENDS[-1] != guest_backend
-    ):
+    if settings.ENABLED and guest_backend in django_settings.AUTHENTICATION_BACKENDS:
         checks.append(
             Warning(
-                "The GuestBackend is not the last item in AUTHENTICATION_BACKENDS. This may have unintended effects.",
-                hint='Move the "guest_user.backends.GuestBackend" to the last item in the list.',
+                "GuestBackend is in AUTHENTICATION_BACKENDS. This backend "
+                "allowed guest re-login by identifier alone in older versions "
+                "and is deprecated. Remove it; guest sessions are created via "
+                "maybe_create_guest_user() and GUEST_USER_LOGIN_BACKEND.",
+                hint=(
+                    'Remove "guest_user.backends.GuestBackend" from '
+                    "AUTHENTICATION_BACKENDS."
+                ),
                 obj="settings",
                 id="guest_user.W001",
             )

--- a/guest_user/functions.py
+++ b/guest_user/functions.py
@@ -5,7 +5,7 @@ import uuid
 from urllib.parse import urlparse
 
 from django.apps import apps as django_apps
-from django.contrib.auth import authenticate, get_user_model, login
+from django.contrib.auth import get_user_model, login
 from django.core.exceptions import ImproperlyConfigured
 from django.shortcuts import resolve_url
 
@@ -16,8 +16,13 @@ def maybe_create_guest_user(request):
     """
     Create a guest user and log them in.
 
-    This function will create and authenticate a new guest user should the visitor
-    not be authenticated already and their user agent isn't on the block list.
+    This function will create a new guest user should the visitor not be
+    authenticated already and their user agent isn't on the block list.
+
+    The guest is logged in with ``GUEST_USER_LOGIN_BACKEND`` (``ModelBackend``
+    by default). ``guest_user.backends.GuestBackend`` must **not** be registered
+    in ``AUTHENTICATION_BACKENDS`` — guests cannot re-authenticate via the login
+    form.
 
     """
     assert hasattr(
@@ -27,19 +32,9 @@ def maybe_create_guest_user(request):
     if settings.ENABLED and request.user.is_anonymous:
         user_agent = request.META.get("HTTP_USER_AGENT", "")
         if not settings.BLOCKED_USER_AGENTS.search(user_agent):
-            UserModel = get_user_model()
             Guest = get_guest_model()
             user = Guest.objects.create_guest_user(request)
-            user = authenticate(
-                request=request,
-                username=getattr(user, UserModel.USERNAME_FIELD),
-                password=getattr(user, UserModel.PASSWORD_FIELD),
-                )
-            assert user, (
-                "Guest authentication failed. Do you have "
-                "'guest_user.backends.GuestBackend' in AUTHENTICATION_BACKENDS?"
-            )
-            login(request, user)
+            login(request, user, backend=settings.LOGIN_BACKEND)
 
 
 def get_guest_model():

--- a/guest_user/models.py
+++ b/guest_user/models.py
@@ -47,19 +47,17 @@ class GuestManager(models.Manager.from_queryset(GuestQuerySet)):
         :param username: The preferred username for the user, may be None.
 
         """
-        if username is None:
-            username = self.generate_username()
-            email = f"guest+{username}@liqd.net"
-            password = self.generate_password()
-
         user = None
         while user is None:
+            if username is None:
+                username = self.generate_username()
+            email = f"guest+{username}@liqd.net"
+            password = self.generate_password()
             try:
                 with transaction.atomic():
                     user = UserModel.objects.create_user(username, email, password)
             except IntegrityError:
-                # retry with a new username
-                username = self.generate_username()
+                username = None
 
         self.create(user=user)
         if request is not None:

--- a/test_proj/settings.py
+++ b/test_proj/settings.py
@@ -110,7 +110,6 @@ AUTH_PASSWORD_VALIDATORS = [
 
 AUTHENTICATION_BACKENDS = [
     "django.contrib.auth.backends.ModelBackend",
-    "guest_user.backends.GuestBackend",
 ]
 
 # Internationalization

--- a/test_proj/test_backends.py
+++ b/test_proj/test_backends.py
@@ -1,7 +1,7 @@
 import pytest
-from django.contrib.auth import get_user_model
+from django.contrib.auth import authenticate, get_user_model
 from guest_user.backends import GuestBackend
-from guest_user.functions import get_guest_model
+from guest_user.functions import get_guest_model, maybe_create_guest_user
 
 
 @pytest.fixture
@@ -22,9 +22,31 @@ def test_backend_does_not_authenticate_normal_user(backend):
 
 
 @pytest.mark.django_db
-def test_backend_authenticates_guest_user(backend):
+def test_backend_does_not_authenticate_guest_user(backend):
     GuestModel = get_guest_model()
     guest = GuestModel.objects.create_guest_user()
 
-    backend_guest = backend.authenticate(request=None, username=guest.username)
-    assert backend_guest.username == guest.username
+    assert backend.authenticate(request=None, username=guest.username) is None
+
+
+@pytest.mark.django_db
+def test_maybe_create_guest_user_logs_in(client):
+    assert client.session.get("_auth_user_id") is None
+
+    from django.contrib.auth.models import AnonymousUser
+    from django.test import RequestFactory
+
+    request = RequestFactory().get("/")
+    request.user = AnonymousUser()
+    request.session = client.session
+    maybe_create_guest_user(request)
+
+    assert request.user.is_authenticated
+
+
+@pytest.mark.django_db
+def test_guest_cannot_relogin_via_authenticate(client):
+    GuestModel = get_guest_model()
+    guest = GuestModel.objects.create_guest_user()
+
+    assert authenticate(username=guest.username, password="wrong") is None

--- a/test_proj/test_managers.py
+++ b/test_proj/test_managers.py
@@ -72,3 +72,32 @@ def test_convert_sends_signal():
 
     assert not is_guest_user(converted_user)
     assert guest_user.id == converted_user.id
+
+
+@pytest.mark.django_db
+def test_create_guest_user_with_explicit_username():
+    GuestModel = get_guest_model()
+    guest = GuestModel.objects.create_guest_user(username="customguest")
+
+    assert guest.username == "customguest"
+    assert guest.email == "guest+customguest@liqd.net"
+    assert guest.password
+
+
+@pytest.mark.django_db
+def test_create_guest_user_retries_on_username_collision(monkeypatch):
+    GuestModel = get_guest_model()
+    usernames = iter(["taken", "free"])
+
+    def fake_username():
+        return next(usernames)
+
+    monkeypatch.setattr(GuestModel, "generate_username", fake_username)
+
+    UserModel = get_user_model()
+    UserModel.objects.create_user("taken", "taken@example.com", "password")
+
+    guest = GuestModel.objects.create_guest_user()
+
+    assert guest.username == "free"
+    assert guest.email == "guest+free@liqd.net"


### PR DESCRIPTION
maybe_create_guest_user logs guests in via ModelBackend instead of GuestBackend (which ignored passwords and allowed re-login). GuestBackend authenticate() is disabled; W001 now warns if the backend is registered. Also fix IntegrityError retry and explicit-username paths in create_guest_user.